### PR TITLE
Fixed bug: invalid frequency if x % block_size != 0

### DIFF
--- a/frequency.py
+++ b/frequency.py
@@ -75,7 +75,7 @@ def block_frequency(i, j, W, angle, im_load):
 def freq(im, W, angles):
     (x, y) = im.size
     im_load = im.load()
-    freqs = [[0] for i in range(0, x, W)]
+    freqs = [[0] for i in range(0, x / W)]
 
     for i in range(1, x / W - 1):
         for j in range(1, y / W - 1):


### PR DESCRIPTION
Hi, Przemysław!
I used your lib and I liked it!

I found a little bug using Gabor filter:
If image width (`x`) is not fully divisible by `block_size` the `IndexError` appears.

As it turned out the problem was in freq() function.
freqs list is initialized with one extra element if `x % W != 0` which is ignored in following i-j cycle.

Thank you for this lib, it was really helpful!

